### PR TITLE
Fixes for modern Python stack

### DIFF
--- a/betsi/gui.py
+++ b/betsi/gui.py
@@ -392,6 +392,8 @@ class BETSI_widget(QWidget):
         if self.current_fig is not None:
             self.current_fig.clear()
             self.current_fig_2.clear()
+        if not self.target_filepath:
+            return
         try:
             # check if the figure has been closed, if it doesn't reset it to none and replot
             if self.current_fig is not None and not plt.fignum_exists(self.current_fig.number):

--- a/betsi/lib.py
+++ b/betsi/lib.py
@@ -126,7 +126,7 @@ class BETResult:
                     [np.ones([num_points, 1]), pressure[:, None]], axis=1)
                 params, residuals, _, _ = np.linalg.lstsq(
                     x[i:j, :], self.linear_y[i:j], rcond=None)
-                if residuals:
+                if len(residuals):
                     r2 = 1. - residuals / \
                         (self.linear_y[i:j].size * self.linear_y[i:j].var())
                     self.fit_rsquared[i, j - 1] = r2

--- a/betsi/plotting.py
+++ b/betsi/plotting.py
@@ -115,7 +115,7 @@ def regression_diagnostics_plots(bet_filtered, name, fig_2=None):
     sns.regplot(x=fit_values, y=fit_stud_resid_abs_sqrt, scatter=False, ci=False, lowess=True, line_kws={'color': 'black', 'lw': 1, 'alpha': .75}, ax=scale_loc)
     scale_loc.set_title('Scale-Location')
     scale_loc.set_xlabel('Fitted Values')
-    scale_loc.set_ylabel('$\mathregular{\sqrt{|Studentized\ Residuals|}}$')
+    scale_loc.set_ylabel(r'$\mathregular{\sqrt{|Studentized\ Residuals|}}$')
     scale_loc.tick_params(axis='both', which='major', labelsize=9)
     scale_loc.tick_params(axis='both', which='minor', labelsize=9)
 
@@ -261,10 +261,10 @@ def plot_isotherm(bet_filtered, ax=None):
     # plot pchip interpolation
     ax.plot(bet_filtered.x_range, pchip_interpolate(bet_filtered.pressure, bet_filtered.q_adsorbed, bet_filtered.x_range), color='black', alpha=.75, label='Pchip Interpolation')
     # plot corresponding pressure
-    ax.scatter(bet_filtered.corresponding_pressure_pchip[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='^', color='blue', edgecolors='blue', label='$\mathregular{N_m}$ Read', alpha=0.50)
+    ax.scatter(bet_filtered.corresponding_pressure_pchip[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='^', color='blue', edgecolors='blue', label=r'$\mathregular{N_m}$ Read', alpha=0.50)
 
     # Plot selected Monolayer loading (single point)
-    ax.scatter(bet_filtered.calc_pressure[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='v', color='green', edgecolors='green', label='$\mathregular{N_m}$ BET')
+    ax.scatter(bet_filtered.calc_pressure[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='v', color='green', edgecolors='green', label=r'$\mathregular{N_m}$ BET')
 
     # Plot the BET curve derived from BET theory
     ax.plot(bet_filtered.x_range, bet_filtered.bet_curve, c='g', label='BET Fit', alpha=.5)
@@ -585,7 +585,7 @@ def plot_monolayer_loadings(bet_filtered, ax=None):
     ax.plot(bet_filtered.x_range, pchip_interpolate(bet_filtered.pressure, bet_filtered.q_adsorbed, bet_filtered.x_range), color='black',alpha=.5, label='Pchip Interpolation')
 
     # Plot the valid monolayer loadings.
-    ax.scatter(bet_filtered.valid_calc_pressures, bet_filtered.valid_nm, marker='^', color='blue', edgecolors='blue', label='$\mathregular{N_m}$ valid', alpha=0.5)
+    ax.scatter(bet_filtered.valid_calc_pressures, bet_filtered.valid_nm, marker='^', color='blue', edgecolors='blue', label=r'$\mathregular{N_m}$ valid', alpha=0.5)
 
     # Plot the valid optimum linear range
     ax.scatter(bet_filtered.pressure[min_i:min_j + 1], bet_filtered.q_adsorbed[min_i:min_j + 1], marker='s', color='red', edgecolors='red', label='Linear Range', alpha=0.5)

--- a/betsi/plotting.py
+++ b/betsi/plotting.py
@@ -75,7 +75,7 @@ def regression_diagnostics_plots(bet_filtered, name, fig_2=None):
 
     # "Residual vs fitted" plot
     resid_vs_fit = fig_2.add_subplot(2, 2, 1)
-    sns.residplot(fit_values, fit_resid, data=dataframe,
+    sns.residplot(x=fit_values, y=fit_resid,
                   lowess=True,
                   scatter_kws={'alpha': .5, 'color': 'red'},
                   line_kws={'color': 'black', 'lw': 1, 'alpha': 0.75},
@@ -112,7 +112,7 @@ def regression_diagnostics_plots(bet_filtered, name, fig_2=None):
     # "Scale-location" plot
     scale_loc = fig_2.add_subplot(2, 2, 3)
     scale_loc.scatter(fit_values, fit_stud_resid_abs_sqrt, alpha=.5, c = 'red')
-    sns.regplot(fit_values, fit_stud_resid_abs_sqrt, scatter=False, ci=False, lowess=True, line_kws={'color': 'black', 'lw': 1, 'alpha': .75}, ax=scale_loc)
+    sns.regplot(x=fit_values, y=fit_stud_resid_abs_sqrt, scatter=False, ci=False, lowess=True, line_kws={'color': 'black', 'lw': 1, 'alpha': .75}, ax=scale_loc)
     scale_loc.set_title('Scale-Location')
     scale_loc.set_xlabel('Fitted Values')
     scale_loc.set_ylabel('$\mathregular{\sqrt{|Studentized\ Residuals|}}$')
@@ -131,7 +131,7 @@ def regression_diagnostics_plots(bet_filtered, name, fig_2=None):
     # "Residuals vs leverage" plot
     res_vs_lev = fig_2.add_subplot(2, 2, 4)
     res_vs_lev.scatter(fit_leverage, fit_stud_resid, alpha=.5, color = 'red')
-    sns.regplot(fit_leverage, fit_stud_resid, scatter=False, ci=False, lowess=True, line_kws={'color': 'black', 'lw': 1, 'alpha': .75}, ax=res_vs_lev)
+    sns.regplot(x=fit_leverage, y=fit_stud_resid, scatter=False, ci=False, lowess=True, line_kws={'color': 'black', 'lw': 1, 'alpha': .75}, ax=res_vs_lev)
     res_vs_lev.axes.set_title('Residuals vs Leverage')
     res_vs_lev.axes.set_xlabel('Leverage')
     res_vs_lev.axes.set_ylabel('Studentized Residuals')

--- a/betsi/plotting.py
+++ b/betsi/plotting.py
@@ -261,10 +261,10 @@ def plot_isotherm(bet_filtered, ax=None):
     # plot pchip interpolation
     ax.plot(bet_filtered.x_range, pchip_interpolate(bet_filtered.pressure, bet_filtered.q_adsorbed, bet_filtered.x_range), color='black', alpha=.75, label='Pchip Interpolation')
     # plot corresponding pressure
-    ax.scatter(bet_filtered.corresponding_pressure_pchip[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='^', color='blue', edgecolor='blue', label='$\mathregular{N_m}$ Read', alpha=0.50)
+    ax.scatter(bet_filtered.corresponding_pressure_pchip[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='^', color='blue', edgecolors='blue', label='$\mathregular{N_m}$ Read', alpha=0.50)
 
     # Plot selected Monolayer loading (single point)
-    ax.scatter(bet_filtered.calc_pressure[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='v', color='green', edgecolors='green', edgecolor='green', label='$\mathregular{N_m}$ BET')
+    ax.scatter(bet_filtered.calc_pressure[min_i, min_j], bet_filtered.nm[min_i, min_j], marker='v', color='green', edgecolors='green', label='$\mathregular{N_m}$ BET')
 
     # Plot the BET curve derived from BET theory
     ax.plot(bet_filtered.x_range, bet_filtered.bet_curve, c='g', label='BET Fit', alpha=.5)
@@ -638,9 +638,9 @@ def plot_box_and_whisker(bet_filtered, ax=None):
     x_2 = np.random.normal(1, 0.04, size=len(y_2))
 
     # Plot the filtered BET areas
-    ax.scatter(x_2, y_2, alpha=0.5, color='red', edgecolor='red')
-    ax.scatter(x, y, color='blue', edgecolor='blue', alpha=0.5)
-    ax.scatter(x_min, y_min, marker='s', color='orange', edgecolor='orange')
+    ax.scatter(x_2, y_2, alpha=0.5, color='red', edgecolors='red')
+    ax.scatter(x, y, color='blue', edgecolors='blue', alpha=0.5)
+    ax.scatter(x_min, y_min, marker='s', color='orange', edgecolors='orange')
 
     if len(x)==0:
         ax.set_xlim([.75,1.25])

--- a/executables/BETSI_v2_0_linux-faster_startup.zip
+++ b/executables/BETSI_v2_0_linux-faster_startup.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8dc2a7c7dc1478c65480a4a6485c8bf4e79c8bc53195d981337b0bdc47d39203
-size 119517011

--- a/executables/BETSI_v2_0_linux.zip
+++ b/executables/BETSI_v2_0_linux.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fe6a2109a0c40e5fef4be93cf4fefb0f510a77fa996e09f3f8470581c0553d4
-size 117570162

--- a/executables/BETSI_v2_0_mac.zip
+++ b/executables/BETSI_v2_0_mac.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eff4fd62f6050c8bb5b9744d2cb9cb68f2d9c479337dc6c2b6dec047f2fde67
-size 117573850

--- a/executables/BETSI_v2_0_mac_faster_startup.zip
+++ b/executables/BETSI_v2_0_mac_faster_startup.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a134968d4c6d701f1e71996807c0a0490a99e134b9016ef1048dc937e3bf68dc
-size 239720524

--- a/executables/BETSI_v2_0_windows.exe
+++ b/executables/BETSI_v2_0_windows.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0d973d7b1461fe02cfd1e82bafa5d7e634076dfd09dcb86378551e48cbb5a47
-size 183182879

--- a/executables/BETSI_v2_0_windows_faster_startup.zip
+++ b/executables/BETSI_v2_0_windows_faster_startup.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7845386f43b94ac94d55ff6daf8280db4d83386880f15507c64c5cc970603899
-size 171295906

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.19.3
-scipy==1.5.4
-matplotlib==3.2.2
-PyQt5==5.9.2
-pandas==1.1.5
-seaborn==0.11.0
-statsmodels==0.12.1
-xlrd==2.0.1
+numpy
+scipy
+matplotlib
+PyQt5
+pandas
+seaborn
+statsmodels
+xlrd


### PR DESCRIPTION
BETSI does not work with more recent versions of numpy/scipy/seaborn. And older versions of these packages are not necessarily compatible with modern Python version (3.12 and later). So, in order to run BETSI on recent Python versions, a few fixes are necessary.